### PR TITLE
Remove dependency on python3-distutils

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -11,7 +11,6 @@ Build-Depends: cmake,
                libgz-utils3-dev,
                python3,
                python3-dev,
-               python3-distutils,
                python3-pybind11,
                ruby-dev,
                swig
@@ -75,7 +74,6 @@ Description: Gazebo Math Library - Eigen3 Development files
 Package: python3-gz-math8
 Architecture: any
 Depends: libgz-math8 (= ${binary:Version}),
-         python3-distutils,
          python3-pybind11,
          ${misc:Depends},
          ${python3:Depends}


### PR DESCRIPTION
No longer needed as of gazebosim/gz-math#587.